### PR TITLE
bugfix #69: the-email-field-is-overloaded-by-description-text

### DIFF
--- a/src/containers/guest-home-page/forgot-password/ForgotPassword.styles.js
+++ b/src/containers/guest-home-page/forgot-password/ForgotPassword.styles.js
@@ -17,7 +17,8 @@ export const styles = {
   titleWithDescription: {
     wrapper: {
       textAlign: 'start',
-      m: 0
+      m: 0,
+      paddingBottom: '25px'
     },
     title: {
       typography: 'h5',


### PR DESCRIPTION
Hello to everybody!

I fixed bug #69:
 'The “Email” input field is overlapped by description text on the password reset pop-up'.

The style for 'titleWithDescription' has been changed in 'ForgotPassword.styles.js':
- paddingBottom: '20px' has been added.

Thanks!