### PR TITLE
sign in/sign up with Google button not overflow container when scaling

### DIFF
--- a/src/containers/guest-home-page/login-dialog/LoginDialog.styles.js
+++ b/src/containers/guest-home-page/login-dialog/LoginDialog.styles.js
@@ -37,7 +37,7 @@ const style = {
     lineHeight: '48px'
   },
   form: {
-    overflow: 'auto',
+    overflow: 'visible',
     maxWidth: { xs: '315px', md: '343px' },
     pt: '16px',
     pr: { xs: '8px', sm: '96px', md: '80px', lg: '96px' },

--- a/src/containers/guest-home-page/signup-dialog/SignupDialog.styles.js
+++ b/src/containers/guest-home-page/signup-dialog/SignupDialog.styles.js
@@ -37,7 +37,7 @@ export const styles = {
     lineHeight: '48px'
   },
   form: {
-    overflow: 'auto',
+    overflow: 'visible',
     maxWidth: { xs: '343px', md: '400px' },
     pt: '16px',
     pr: { xs: '8px', sm: '96px', md: '80px', lg: '96px' },


### PR DESCRIPTION
now sign in/sign up with Google button not overflow container when scaling

**before:**
![image](https://github.com/Space2Study-UA-1156/Client-01/assets/32570823/cbcba4d3-c067-4c82-a8a8-182f9bc731d5)

**now:**
![image](https://github.com/Space2Study-UA-1156/Client-01/assets/32570823/647eedce-5e4d-4587-af1b-8a8e5a62d75b)
