### PR TITLE
Login form overflows its container on tablets

### DIFF
--- a/src/containers/guest-home-page/login-form/LoginForm.styles.js
+++ b/src/containers/guest-home-page/login-form/LoginForm.styles.js
@@ -2,7 +2,7 @@ export const styles = {
   form: {
     display: 'flex',
     flexDirection: 'column',
-    minWidth: { sm: '340px' }
+    maxWidth: { md: '343px' }
   },
   input: {
     maxWidth: '343px'


### PR DESCRIPTION
Now the login form doesn't overflow its container.

**before:**
![image](https://github.com/Space2Study-UA-1156/Client-01/assets/32570823/07f0e780-7d14-4770-851c-c68efc75faae)


**now:**
![image](https://github.com/Space2Study-UA-1156/Client-01/assets/32570823/4d0b7b71-f526-46c2-a04b-fab171fc656c)
