### PR TITLE
bugfix #72: correct a mistake in Already-have-a-Space2Study-account text

### DIFF
--- a/src/constants/translations/en/signup.json
+++ b/src/constants/translations/en/signup.json
@@ -7,7 +7,7 @@
   "and": "and",
   "googleButton": "Sign up with Google",
   "continue": "or continue",
-  "haveAccount": "Already have a tutor account?",
+  "haveAccount": "Already have a Space2Study account?",
   "joinUs": "Login!",
   "confirmEmailTitle": "Your email address needs to be verified",
   "confirmEmailMessage": "We sent a confirmation email to: ",


### PR DESCRIPTION
Hello to everybody!

The text below the "Sign Up with Google" button is changed.
How it was: 'Already have a tutor account?'
Now: 'Already have a Space2Study account?'

Please note that this text has also changed in the field that opens when you click the “Become a student” button. Previously it was: “Already have a tutor account?”

Thanks.
