### PR TITLE
[Categories] Implement list of categories block

### DIFF
--- a/src/containers/category-list/CategoryList.jsx
+++ b/src/containers/category-list/CategoryList.jsx
@@ -1,0 +1,103 @@
+import { Box } from '@mui/material'
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useSearchParams } from 'react-router-dom'
+import AppButton from '~/components/app-button/AppButton'
+import CategoryCard from '~/components/category-card/CategoryCard'
+import Loader from '~/components/loader/Loader'
+import { styles } from '~/containers/category-list/CategoryList.styles'
+import useAxios from '~/hooks/use-axios'
+import { categoryService } from '~/services/category-service'
+
+// TODO: update path of category images in db and import images
+import categoryImg from '~/assets/img/student-home-page/service_icon.png'
+
+const itemsPerPage = 24
+
+const CategoryList = () => {
+  const { t } = useTranslation()
+  const [searchParams] = useSearchParams()
+  const [categories, setCategories] = useState([])
+  const [page, setPage] = useState(1)
+  const [isMore, setIsMore] = useState(true)
+
+  const categoryName = searchParams.get('categoryName')
+
+  const onResponse = (res) => {
+    if (res?.items) {
+      setCategories([...categories, ...res.items])
+    }
+    if (res?.count < itemsPerPage) {
+      setIsMore(false)
+    }
+  }
+
+  const { loading, fetchData } = useAxios({
+    service: categoryService.getCategories,
+    fetchOnMount: false,
+    defaultResponse: null,
+    onResponse
+  })
+
+  useEffect(() => {
+    setPage(1)
+    setCategories([])
+  }, [categoryName])
+
+  useEffect(() => {
+    fetchData({
+      name: categoryName,
+      limit: itemsPerPage,
+      skip: (page - 1) * itemsPerPage
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [page, categoryName])
+
+  const handleViewMoreClick = () => {
+    setPage(page + 1)
+  }
+
+  if (loading && !categories.length) {
+    return (
+      <Box component='section' sx={styles.root}>
+        <Loader size={50} />
+      </Box>
+    )
+  }
+
+  if (!loading && !categories.length) {
+    return (
+      <Box component='section' sx={styles.root}>
+        <Box>Sorry, no results found</Box>
+      </Box>
+    )
+  }
+
+  return (
+    <Box component='section' sx={styles.root}>
+      <Box sx={styles.grid}>
+        {categories.map(({ _id, name, totalOffers }) => (
+          <CategoryCard
+            id={_id}
+            img={categoryImg}
+            key={_id}
+            title={name}
+            totalOffers={totalOffers.student + totalOffers.tutor}
+          />
+        ))}
+      </Box>
+      {isMore && (
+        <AppButton
+          loading={loading}
+          onClick={handleViewMoreClick}
+          sx={styles.button}
+          variant='contained'
+        >
+          {t('categoriesPage.viewMore')}
+        </AppButton>
+      )}
+    </Box>
+  )
+}
+
+export default CategoryList

--- a/src/containers/category-list/CategoryList.styles.js
+++ b/src/containers/category-list/CategoryList.styles.js
@@ -1,0 +1,29 @@
+import { mainShadow } from '~/styles/app-theme/custom-shadows'
+
+export const styles = {
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center'
+  },
+  grid: {
+    display: 'grid',
+    alignItems: 'center',
+    gridTemplateColumns: {
+      xs: '1fr',
+      sm: 'repeat(2, 1fr)',
+      lg: 'repeat(3, 360px)'
+    },
+    gap: '24px',
+    mb: '30px'
+  },
+  button: {
+    color: 'primary.900',
+    padding: '16px 32px',
+    backgroundColor: 'basic.grey',
+    boxShadow: mainShadow,
+    '&:hover': {
+      color: 'basic.white'
+    }
+  }
+}

--- a/tests/unit/containers/category-list/CategoryList.spec.jsx
+++ b/tests/unit/containers/category-list/CategoryList.spec.jsx
@@ -1,0 +1,128 @@
+import { fireEvent, screen } from '@testing-library/react'
+import { expect, vi } from 'vitest'
+import CategoryList from '~/containers/category-list/CategoryList'
+import useAxios from '~/hooks/use-axios'
+import { renderWithProviders } from '../../../test-utils'
+
+vi.mock('~/components/category-card/CategoryCard', () => ({
+  __esModule: true,
+  default: ({ img, title, totalOffers }) => (
+    <div data-testid='card'>
+      <img alt={title} src={img} />
+      <h2>{title}</h2>
+      <p>{totalOffers}</p>
+    </div>
+  )
+}))
+
+vi.mock('~/components/loader/Loader', () => ({
+  __esModule: true,
+  default: () => <div data-testid='loader'></div>
+}))
+
+vi.mock('~/hooks/use-axios')
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useSearchParams: () => [{ get: vi.fn() }, vi.fn()]
+  }
+})
+
+const mockFirstResponse = {
+  items: [
+    {
+      _id: 1,
+      name: 'Languages',
+      img: 'learnImg.png',
+      title: 'Languages',
+      totalOffers: {
+        student: 234,
+        tutor: 234
+      }
+    }
+  ],
+  count: 24
+}
+const mockSecondResponse = {
+  items: [
+    {
+      _id: 2,
+      name: 'Languages',
+      img: 'learnImg.png',
+      title: 'Languages',
+      totalOffers: {
+        student: 234,
+        tutor: 234
+      }
+    }
+  ],
+  count: 24
+}
+
+describe('CategoryList container', () => {
+  it('should render "Sorry, no results found"', () => {
+    const fakeData = {
+      loading: false,
+      fetchData: () => vi.fn()
+    }
+    useAxios.mockImplementation(() => fakeData)
+    renderWithProviders(<CategoryList />)
+
+    expect(screen.getByText('Sorry, no results found')).toBeInTheDocument()
+  })
+
+  it('should render Loader', () => {
+    const fakeData = {
+      loading: true,
+      fetchData: vi.fn()
+    }
+    useAxios.mockImplementation(() => fakeData)
+    renderWithProviders(<CategoryList />)
+
+    expect(screen.getByTestId('loader')).toBeInTheDocument()
+  })
+
+  it('should render more cards after "View more" button click', () => {
+    const mockFetchData = vi
+      .fn()
+      .mockImplementationOnce(() => mockFirstResponse)
+      .mockImplementationOnce(() => mockSecondResponse)
+    useAxios.mockImplementation(({ onResponse }) => ({
+      loading: false,
+      fetchData: () => {
+        onResponse(mockFetchData())
+      }
+    }))
+    renderWithProviders(<CategoryList />)
+
+    expect(screen.getAllByTestId('card')).toHaveLength(1)
+
+    fireEvent.click(screen.getByText('categoriesPage.viewMore'))
+
+    expect(screen.getAllByTestId('card')).toHaveLength(2)
+  })
+
+  it('"View more" button should disappear if there are no more cards to display', () => {
+    const mockFetchData = vi
+      .fn()
+      .mockImplementationOnce(() => mockFirstResponse)
+      .mockImplementationOnce(() => ({
+        items: [],
+        count: 0
+      }))
+    useAxios.mockImplementation(({ onResponse }) => ({
+      loading: false,
+      fetchData: () => {
+        onResponse(mockFetchData())
+      }
+    }))
+    renderWithProviders(<CategoryList />)
+
+    const btn = screen.getByText('categoriesPage.viewMore')
+    expect(btn).toBeInTheDocument()
+    fireEvent.click(btn)
+    expect(btn).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
- [x] When user clicks on category card, she/he should be redirected to "subjects" page with list of all subjects related to that category
- [x]  "View more" button should render more cards
- [x]  "View more" button should disapear if there are no more cards to display

Currently, only one category icon is used on the client side. It is necessary to update the category data in the database and get the name/path to them and the color from the database


![image](https://github.com/Space2Study-UA-1156/Client-01/assets/32570823/a727d33b-0562-4105-b047-b8b912767968)

![image](https://github.com/Space2Study-UA-1156/Client-01/assets/32570823/0c894d38-e826-4d4c-ad8a-022de4c3cc63)

