### PR TITLE
SubjectList container with reusable useViewMore hook for data fetching

### DIFF
--- a/src/components/card-list/CardList.jsx
+++ b/src/components/card-list/CardList.jsx
@@ -1,0 +1,12 @@
+import Box from '@mui/material/Box'
+import { styles as defaultStyles } from '~/components/card-list/CardList.styles'
+
+const CardList = ({ cards, styles = defaultStyles }) => {
+  return (
+    <Box component='section' sx={styles.root}>
+      <Box sx={styles.grid}>{cards}</Box>
+    </Box>
+  )
+}
+
+export default CardList

--- a/src/components/card-list/CardList.styles.js
+++ b/src/components/card-list/CardList.styles.js
@@ -1,0 +1,12 @@
+export const styles = {
+  root: {},
+  grid: {
+    display: 'grid',
+    gap: '20px',
+    gridTemplateColumns: {
+      xs: 'repeat(1, 1fr)',
+      sm: 'repeat(2, 1fr)',
+      md: 'repeat(3, 1fr)'
+    }
+  }
+}

--- a/src/components/category-card/CategoryCard.styles.js
+++ b/src/components/category-card/CategoryCard.styles.js
@@ -1,7 +1,6 @@
 export const styles = {
   card: {
     boxSizing: 'border-box',
-    maxWidth: '360px',
     width: '100%',
     padding: { xs: '20px 30px', lg: '25px 32px' },
     display: 'flex',

--- a/src/containers/subject-list/SubjectList.jsx
+++ b/src/containers/subject-list/SubjectList.jsx
@@ -16,7 +16,7 @@ import { authRoutes } from '~/router/constants/authRoutes'
 
 const CATEGORY_ID_SEARCH_PARAMS_KEY = 'categoryId'
 
-const SubjectList = () => {
+const SubjectList = ({ cardsPerPage = 3 }) => {
   const { t } = useTranslation()
   const [searchParams] = useSearchParams()
   const categoryId = searchParams.get(CATEGORY_ID_SEARCH_PARAMS_KEY)
@@ -29,7 +29,7 @@ const SubjectList = () => {
   const { data, handleViewMore, isViewMoreVisable, error, loading } =
     useViewMore({
       service: serviceFunction,
-      cardsPerPage: 1
+      cardsPerPage
     })
 
   const subjects = data.map((subject) => (
@@ -43,7 +43,7 @@ const SubjectList = () => {
     />
   ))
 
-  if (error) {
+  if (error || (!data.length && !loading)) {
     return (
       <Box sx={styles.notFoundContainer}>
         <CategoriesResultsNotFound />

--- a/src/containers/subject-list/SubjectList.jsx
+++ b/src/containers/subject-list/SubjectList.jsx
@@ -1,0 +1,75 @@
+import { useCallback } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+
+import Box from '@mui/material/Box'
+import CardList from '~/components/card-list/CardList'
+import AppButton from '~/components/app-button/AppButton'
+import CategoryCard from '~/components/category-card/CategoryCard'
+import CategoriesResultsNotFound from '~/containers/categories-results-not-found/CategoriesResultsNotFound'
+
+import useViewMore from '~/hooks/use-view-more'
+import { subjectService } from '~/services/subject-service'
+import { styles } from '~/containers/subject-list/SubjectList.styles'
+import { withLoader } from '~/hocs/withLoader'
+import { authRoutes } from '~/router/constants/authRoutes'
+
+const CATEGORY_ID_SEARCH_PARAMS_KEY = 'categoryId'
+
+const SubjectList = () => {
+  const { t } = useTranslation()
+  const [searchParams] = useSearchParams()
+  const categoryId = searchParams.get(CATEGORY_ID_SEARCH_PARAMS_KEY)
+
+  const serviceFunction = useCallback(
+    (params) => subjectService.getSubjects(params, categoryId),
+    [categoryId]
+  )
+
+  const { data, handleViewMore, isViewMoreVisable, error, loading } =
+    useViewMore({
+      service: serviceFunction,
+      cardsPerPage: 1
+    })
+
+  const subjects = data.map((subject) => (
+    <CategoryCard
+      color={subject.category?.appearance?.color}
+      icon={subject.category?.appearance?.path}
+      key={subject._id}
+      title={subject.name}
+      to={`${authRoutes.findOffers.path}?categoryId=${subject.category?._id}&subjectId=${subject._id}`}
+      totalOffers={subject.totalOffers?.student + subject.totalOffers?.tutor}
+    />
+  ))
+
+  if (error) {
+    return (
+      <Box sx={styles.notFoundContainer}>
+        <CategoriesResultsNotFound />
+      </Box>
+    )
+  }
+
+  return (
+    <Box>
+      <CardListWithLoader cards={subjects} isLoading={loading} />
+
+      {isViewMoreVisable && (
+        <AppButton
+          disabled={loading}
+          onClick={handleViewMore}
+          size='extraLarge'
+          sx={styles.button}
+          variant='tonal'
+        >
+          {t('subjectsPage.subjects.viewMore')}
+        </AppButton>
+      )}
+    </Box>
+  )
+}
+
+const CardListWithLoader = withLoader(CardList)
+
+export default SubjectList

--- a/src/containers/subject-list/SubjectList.jsx
+++ b/src/containers/subject-list/SubjectList.jsx
@@ -16,7 +16,7 @@ import { authRoutes } from '~/router/constants/authRoutes'
 
 const CATEGORY_ID_SEARCH_PARAMS_KEY = 'categoryId'
 
-const SubjectList = ({ cardsPerPage = 3 }) => {
+const SubjectList = ({ cardsPerPage = 24 }) => {
   const { t } = useTranslation()
   const [searchParams] = useSearchParams()
   const categoryId = searchParams.get(CATEGORY_ID_SEARCH_PARAMS_KEY)

--- a/src/containers/subject-list/SubjectList.styles.jsx
+++ b/src/containers/subject-list/SubjectList.styles.jsx
@@ -1,0 +1,11 @@
+export const styles = {
+  button: {
+    display: 'block',
+    margin: '30px auto 0'
+  },
+  notFoundContainer: {
+    backgroundColor: 'basic.white',
+    borderRadius: '6px',
+    padding: { xs: '32px 25px', md: '112px 25px' }
+  }
+}

--- a/src/hooks/use-view-more.jsx
+++ b/src/hooks/use-view-more.jsx
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import useAxios from '~/hooks/use-axios'
+
+const useViewMore = ({
+  service,
+  searchParamKey = 'page',
+  cardsPerPage = 1
+}) => {
+  const [data, setData] = useState([])
+  const [searchParams, setSearchParams] = useSearchParams()
+  const page = Number(searchParams.get(searchParamKey)) || 1
+  const isPageInSearchParams = searchParams.has(searchParamKey)
+
+  useEffect(() => {
+    if (isPageInSearchParams) {
+      fetchData({ limit: page * cardsPerPage })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const onResponse = useCallback((response) => {
+    setData((prev) => [...prev, ...response.items])
+  }, [])
+
+  const serviceFn = useCallback(
+    (params) => service({ limit: cardsPerPage, ...params }),
+    [service, cardsPerPage]
+  )
+
+  const { response, fetchData, error, loading } = useAxios({
+    service: serviceFn,
+    onResponse,
+    defaultResponse: {},
+    fetchOnMount: !isPageInSearchParams
+  })
+
+  const isViewMoreVisable = response?.count > cardsPerPage * page
+
+  const handleViewMore = () => {
+    const nextPage = page + 1
+    const skip = (nextPage - 1) * cardsPerPage
+
+    searchParams.set(searchParamKey, nextPage)
+    setSearchParams(searchParams)
+
+    fetchData({ skip })
+  }
+
+  return {
+    isViewMoreVisable,
+    data,
+    handleViewMore,
+    loading,
+    error
+  }
+}
+
+export default useViewMore

--- a/src/hooks/use-view-more.jsx
+++ b/src/hooks/use-view-more.jsx
@@ -10,7 +10,8 @@ const useViewMore = ({
   const [data, setData] = useState([])
   const [searchParams, setSearchParams] = useSearchParams()
 
-  const page = Number(searchParams.get(searchParamKey)) || 1
+  const pageUrlValue = Number(searchParams.get(searchParamKey)) || 1
+  const page = pageUrlValue > 0 ? pageUrlValue : 1
   const isPageInSearchParams = searchParams.has(searchParamKey)
 
   useEffect(() => {
@@ -20,18 +21,23 @@ const useViewMore = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  useEffect(() => {
-    if (!searchParams.size) {
-      setData([])
-    }
-  }, [searchParams.size])
-
-  const onResponse = useCallback((response) => {
-    setData((prev) => [...prev, ...response.items])
-  }, [])
+  const onResponse = useCallback(
+    (response) => {
+      if (searchParams.has(searchParamKey)) {
+        setData((prev) => [...prev, ...response.items])
+      } else {
+        setData(response.items)
+      }
+    },
+    [searchParamKey, searchParams]
+  )
 
   const serviceFn = useCallback(
-    (params) => service({ limit: cardsPerPage, ...params }),
+    (params) =>
+      service({
+        limit: cardsPerPage,
+        ...params
+      }),
     [service, cardsPerPage]
   )
 

--- a/src/hooks/use-view-more.jsx
+++ b/src/hooks/use-view-more.jsx
@@ -9,6 +9,7 @@ const useViewMore = ({
 }) => {
   const [data, setData] = useState([])
   const [searchParams, setSearchParams] = useSearchParams()
+
   const page = Number(searchParams.get(searchParamKey)) || 1
   const isPageInSearchParams = searchParams.has(searchParamKey)
 
@@ -18,6 +19,12 @@ const useViewMore = ({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  useEffect(() => {
+    if (!isPageInSearchParams) {
+      setData([])
+    }
+  }, [isPageInSearchParams])
 
   const onResponse = useCallback((response) => {
     setData((prev) => [...prev, ...response.items])
@@ -35,7 +42,7 @@ const useViewMore = ({
     fetchOnMount: !isPageInSearchParams
   })
 
-  const isViewMoreVisable = response?.count > cardsPerPage * page
+  const isViewMoreVisable = response.count > cardsPerPage * page
 
   const handleViewMore = () => {
     const nextPage = page + 1

--- a/src/hooks/use-view-more.jsx
+++ b/src/hooks/use-view-more.jsx
@@ -21,10 +21,10 @@ const useViewMore = ({
   }, [])
 
   useEffect(() => {
-    if (!isPageInSearchParams) {
+    if (!searchParams.size) {
       setData([])
     }
-  }, [isPageInSearchParams])
+  }, [searchParams.size])
 
   const onResponse = useCallback((response) => {
     setData((prev) => [...prev, ...response.items])


### PR DESCRIPTION
https://github.com/Space2Study-UA-1156/Client-01/assets/56509285/de8175fc-8fd7-4558-b94d-e9749785cba2

`useViewMore` hook can be reused in other components
It receives the following arguments: `service` `searchParamKey` `cardsPerPage`

**Example:** 
![image](https://github.com/Space2Study-UA-1156/Client-01/assets/56509285/d40751ff-94bc-4126-9997-ff86663f3e30)

**If you need additional params for your service**, don't forget to spread existing ones. 
`limit` and `skip` are calculated inside the hook

![image](https://github.com/Space2Study-UA-1156/Client-01/assets/56509285/c0c2ce3b-6fe7-4806-a205-9a6bc692c1aa)

