### PR TITLE
Bugfix: Search parameters aren't cleared if the user manually clears the input field

### DIFF
--- a/src/containers/categories-title-input/CategoriesTitleInput.jsx
+++ b/src/containers/categories-title-input/CategoriesTitleInput.jsx
@@ -28,6 +28,12 @@ const CategoriesTitleInput = () => {
   const handleChangeInput = (e) => {
     const value = e.target.value
     setCategoryName(value)
+    if (!value) {
+      setSearchParams((params) => {
+        params.delete('categoryName')
+        return params
+      })
+    }
   }
 
   const handleSearch = () => {


### PR DESCRIPTION
Bug: Search parameters are not cleared if the user manually clears the input field.
Now: Search parameters are deleted if the user manually clears the input field.
