### PR TITLE
SortMenu updated

### DIFF
--- a/src/components/sort-menu/SortMenu.jsx
+++ b/src/components/sort-menu/SortMenu.jsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { Box, MenuItem } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 import Select from '@mui/material/Select'
@@ -6,15 +5,18 @@ import { styles } from '~/components/sort-menu/SortMenu.styles.js'
 import AppButton from '~/components/app-button/AppButton'
 import { useSearchParams } from 'react-router-dom'
 
-const SortMenu = () => {
+const SortMenu = ({ sort, setSort }) => {
   const { t } = useTranslation()
-  const [searchParams, setSearchParams] = useSearchParams()
-  const [sort, setSort] = useState(searchParams.get('sort') || 'newest')
+  const [, setSearchParams] = useSearchParams()
 
   const handleChange = (event) => {
     const newValue = event.target.value
     setSort(newValue)
-    setSearchParams({ ...searchParams, sort: newValue })
+    setSearchParams((params) => {
+      const updatedParams = new URLSearchParams(params)
+      updatedParams.set('sort', newValue)
+      return updatedParams
+    })
   }
 
   return (


### PR DESCRIPTION
Search parameters are set so that you can add a menu to the Fine Offers page. Previously, when selecting a new value in the menu, the search parameters (category, subject, tutor) were reset. The new version of the menu will solve this problem.
The menu has not  been added to the Find Offers page yet.